### PR TITLE
Fix Eager load classes instead of requiring

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/tasks.rb
+++ b/sunspot_rails/lib/sunspot/rails/tasks.rb
@@ -37,7 +37,8 @@ namespace :sunspot do
 
     # Load all the application's models. Models which invoke 'searchable' will register themselves
     # in Sunspot.searchable.
-    Dir.glob(Rails.root.join('app/models/**/*.rb')).each { |path| require path }
+    Rails.application.eager_load!
+    Rails::Engine.subclasses.each { |engine| engine.instance.eager_load! }
 
     # By default, reindex all searchable models
     sunspot_models = Sunspot.searchable


### PR DESCRIPTION
## Problem
Requiring class directly can lead to multiple invocations of the same
Module included stanza. This can cause failures in e.g. rake tasks.

## Solution
Backport the newer logic from upstream sunspot repo.